### PR TITLE
Specify `init` when calling `maximum(...; dims)`

### DIFF
--- a/src/algorithms/dimensionality.jl
+++ b/src/algorithms/dimensionality.jl
@@ -307,7 +307,7 @@ function PeriodicGraph{D}(graph::PeriodicGraph{N}, dims=_dimensionality(graph)) 
     basis, _d = normal_basis(l)
     @assert _d == d
     _invmat::Matrix{Rational{Int}} = inv(Rational.(basis))[1:d,:]
-    maxden = maximum(denominator.(_invmat); dims=2)
+    maxden = maximum(denominator.(_invmat); dims=2, init=0)
     invmat::Matrix{Int} = maximum(maxden; init=0) > 1 ? (maxden .* _invmat) : _invmat
     newedges = Vector{PeriodicEdge{D}}(undef, n)
     if d == D


### PR DESCRIPTION
There's a proposed "minor change" to Julia v1.13 that would make `maximum([], dims=2)` (and other such reductions) an error, akin to how `maximum([])` is an error when `init` is not specified.  This package was flagged as having (at least) one such usage here; it errored in [PkgEval](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/813bcf3_vs_c3e7b1b/report.html).  See https://github.com/JuliaLang/julia/pull/55628 for more details.